### PR TITLE
(feat): enable PNG 2 JPG formatting by default

### DIFF
--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -87,8 +87,8 @@ PNG_COMPRESSION_LEVEL = {{ PNG_COMPRESSION_LEVEL | default(6) }}
 AUTO_WEBP = {{ AUTO_WEBP | default(False) }}
 
 ## Specifies whether non-transparent PNG images should be automatically converted to JPEG
-## Defaults to: False
-AUTO_PNG_TO_JPG = {{ AUTO_PNG_TO_JPG | default(False) }}
+## Defaults to: True
+AUTO_PNG_TO_JPG = {{ AUTO_PNG_TO_JPG | default(True) }}
 
 ## Specify the ratio between 1in and 1px for SVG images. This is only used
 ## whenrasterizing SVG images having their size units in cm or inches.


### PR DESCRIPTION
The goal of this PR is to enable formatting PNG > JPG by default.

Discussion:
https://kitchenstories.slack.com/archives/C03DHNEPQKY/p1686230682873279

There is also the option to do set a filter in the frontend for each image request, but as filters have to be manually enabled, this would require changes as well on our instance. This approach below would also be more holistic.